### PR TITLE
Prevent dummy 1's from passing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# WebStorm
+.idea/

--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ brnv = require('bank-routing-number-validator')
 brnv.ABARoutingNumberIsValid('abcdabcde') //false
 brnv.ABARoutingNumberIsValid('1234567890') //false
 brnv.ABARoutingNumberIsValid('021000021') //true
-brnv.ABARoutingNumberIsValid(021000021) //true
+brnv.ABARoutingNumberIsValid(21000021) //true
 
 ```

--- a/index.js
+++ b/index.js
@@ -11,6 +11,12 @@ function ABARoutingNumberIsValid(routingNumberToTest) {
     return false;
   }
 
+  // Routing numbers provided as strings should be the correct length
+  if (typeof(routingNumberToTest) === 'string' && routingNumberToTest.length !== 9) {
+    return false;
+  }
+
+  // Pad numbers with 0s
   var routing = routingNumberToTest.toString();
   while (routing.length < 9) {
     routing = '0' + routing; //I refuse to import left-pad for this

--- a/test/index.js
+++ b/test/index.js
@@ -39,4 +39,8 @@ describe('ABA Routing Number Tests',function() {
     assert.equal(val.ABARoutingNumberIsValid(null), false);
   });
 
+  it('Should fail on a string with too few digits', function () {
+    assert.equal(val.ABARoutingNumberIsValid('11111111'), false);
+    assert.equal(val.ABARoutingNumberIsValid('21000021'), false);
+  });
 });


### PR DESCRIPTION
The dummy value `11111111` is valid when interpreted as `011111111`. However, spamming 1's on an input form leads this to be a valid routing number.