### PR TITLE
add note in README about octal literals in strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ brnv = require('bank-routing-number-validator')
 brnv.ABARoutingNumberIsValid('abcdabcde') //false
 brnv.ABARoutingNumberIsValid('1234567890') //false
 brnv.ABARoutingNumberIsValid('021000021') //true
-brnv.ABARoutingNumberIsValid(021000021) //true
+brnv.ABARoutingNumberIsValid(021000021) //false - octal literals forbid in strict mode
 
 ```


### PR DESCRIPTION
Example in README is incorrect, octal literals are not allowed in strict mode (which is specified in the source).